### PR TITLE
fix(auth): send empty string instead of undefined if x-access-token h…

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,8 +9,8 @@ const server = new ApolloServer({
     walloraAPI: new WalloraAPI(),
   }),
   context: ({ req }) => ({
-    v1AccessToken: req.headers["x-access-token"],
-    v2AccessToken: req.headers["authorization"]
+    v1AccessToken: req.headers["x-access-token"] || '',
+    v2AccessToken: req.headers["authorization"] 
       ? req.headers["authorization"].replace("Bearer ", "")
       : "",
   }),


### PR DESCRIPTION
…eader is not defined